### PR TITLE
Set clang-format-6.0 as the default clang-format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,5 @@ RUN apt-get update \
         texlive-xetex \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/
+
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100


### PR DESCRIPTION
This allows for Makefiles to just use clang-format instead of
clang-format-6.0 which should work on more systems.